### PR TITLE
Add framework project for Carthage compatibility

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,5 @@
+# A scolling drop-in replacement for UILabel for long texts.
+github "cbpowell/MarqueeLabel" ~> 3.0
+
+# A Swift Autolayout DSL for iOS & OS X
+github "SnapKit/SnapKit" ~> 3.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,2 @@
+github "SnapKit/SnapKit" "3.2.0"
+github "cbpowell/MarqueeLabel" "3.0.3"

--- a/NotificationBanner.xcodeproj/project.pbxproj
+++ b/NotificationBanner.xcodeproj/project.pbxproj
@@ -1,0 +1,365 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		823255AF1EB87313006F95C3 /* BannerColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8232559F1EB87313006F95C3 /* BannerColors.swift */; };
+		823255B01EB87313006F95C3 /* BannerStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823255A01EB87313006F95C3 /* BannerStyle.swift */; };
+		823255B11EB87313006F95C3 /* BaseNotificationBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823255A11EB87313006F95C3 /* BaseNotificationBanner.swift */; };
+		823255B21EB87313006F95C3 /* NotificationBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823255A21EB87313006F95C3 /* NotificationBanner.swift */; };
+		823255B31EB87313006F95C3 /* NotificationBannerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823255A31EB87313006F95C3 /* NotificationBannerQueue.swift */; };
+		823255B41EB87313006F95C3 /* StatusBarNotificationBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823255A41EB87313006F95C3 /* StatusBarNotificationBanner.swift */; };
+		823255B61EB87313006F95C3 /* NotificationBanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 823255A71EB87313006F95C3 /* NotificationBanner.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		823255B91EB8736D006F95C3 /* Cartfile in Resources */ = {isa = PBXBuildFile; fileRef = 823255B81EB8736D006F95C3 /* Cartfile */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		8232558B1EB872AB006F95C3 /* NotificationBanner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NotificationBanner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8232559E1EB87313006F95C3 /* .gitkeep */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
+		8232559F1EB87313006F95C3 /* BannerColors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerColors.swift; sourceTree = "<group>"; };
+		823255A01EB87313006F95C3 /* BannerStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerStyle.swift; sourceTree = "<group>"; };
+		823255A11EB87313006F95C3 /* BaseNotificationBanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseNotificationBanner.swift; sourceTree = "<group>"; };
+		823255A21EB87313006F95C3 /* NotificationBanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationBanner.swift; sourceTree = "<group>"; };
+		823255A31EB87313006F95C3 /* NotificationBannerQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationBannerQueue.swift; sourceTree = "<group>"; };
+		823255A41EB87313006F95C3 /* StatusBarNotificationBanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusBarNotificationBanner.swift; sourceTree = "<group>"; };
+		823255A61EB87313006F95C3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		823255A71EB87313006F95C3 /* NotificationBanner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationBanner.h; sourceTree = "<group>"; };
+		823255B81EB8736D006F95C3 /* Cartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
+		823255BB1EB87CB7006F95C3 /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		823255871EB872AB006F95C3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		823255811EB872AB006F95C3 = {
+			isa = PBXGroup;
+			children = (
+				823255B71EB8735E006F95C3 /* Root Files */,
+				8232558D1EB872AB006F95C3 /* NotificationBanner */,
+				8232558C1EB872AB006F95C3 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		8232558C1EB872AB006F95C3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8232558B1EB872AB006F95C3 /* NotificationBanner.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8232558D1EB872AB006F95C3 /* NotificationBanner */ = {
+			isa = PBXGroup;
+			children = (
+				8232559D1EB87313006F95C3 /* Classes */,
+				823255A51EB87313006F95C3 /* Supporting Files */,
+			);
+			path = NotificationBanner;
+			sourceTree = "<group>";
+		};
+		8232559D1EB87313006F95C3 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				8232559E1EB87313006F95C3 /* .gitkeep */,
+				8232559F1EB87313006F95C3 /* BannerColors.swift */,
+				823255A01EB87313006F95C3 /* BannerStyle.swift */,
+				823255A11EB87313006F95C3 /* BaseNotificationBanner.swift */,
+				823255A21EB87313006F95C3 /* NotificationBanner.swift */,
+				823255A31EB87313006F95C3 /* NotificationBannerQueue.swift */,
+				823255A41EB87313006F95C3 /* StatusBarNotificationBanner.swift */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		823255A51EB87313006F95C3 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				823255A61EB87313006F95C3 /* Info.plist */,
+				823255A71EB87313006F95C3 /* NotificationBanner.h */,
+			);
+			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		823255B71EB8735E006F95C3 /* Root Files */ = {
+			isa = PBXGroup;
+			children = (
+				823255B81EB8736D006F95C3 /* Cartfile */,
+				823255BB1EB87CB7006F95C3 /* Cartfile.resolved */,
+			);
+			name = "Root Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		823255881EB872AB006F95C3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				823255B61EB87313006F95C3 /* NotificationBanner.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		8232558A1EB872AB006F95C3 /* NotificationBanner */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 823255931EB872AB006F95C3 /* Build configuration list for PBXNativeTarget "NotificationBanner" */;
+			buildPhases = (
+				823255861EB872AB006F95C3 /* Sources */,
+				823255871EB872AB006F95C3 /* Frameworks */,
+				823255881EB872AB006F95C3 /* Headers */,
+				823255891EB872AB006F95C3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NotificationBanner;
+			productName = NotificationBanner;
+			productReference = 8232558B1EB872AB006F95C3 /* NotificationBanner.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		823255821EB872AB006F95C3 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0830;
+				ORGANIZATIONNAME = "Dalton Hinterscher";
+				TargetAttributes = {
+					8232558A1EB872AB006F95C3 = {
+						CreatedOnToolsVersion = 8.3.2;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 823255851EB872AB006F95C3 /* Build configuration list for PBXProject "NotificationBanner" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 823255811EB872AB006F95C3;
+			productRefGroup = 8232558C1EB872AB006F95C3 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8232558A1EB872AB006F95C3 /* NotificationBanner */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		823255891EB872AB006F95C3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				823255B91EB8736D006F95C3 /* Cartfile in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		823255861EB872AB006F95C3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				823255B41EB87313006F95C3 /* StatusBarNotificationBanner.swift in Sources */,
+				823255B21EB87313006F95C3 /* NotificationBanner.swift in Sources */,
+				823255AF1EB87313006F95C3 /* BannerColors.swift in Sources */,
+				823255B31EB87313006F95C3 /* NotificationBannerQueue.swift in Sources */,
+				823255B01EB87313006F95C3 /* BannerStyle.swift in Sources */,
+				823255B11EB87313006F95C3 /* BaseNotificationBanner.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		823255911EB872AB006F95C3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		823255921EB872AB006F95C3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		823255941EB872AB006F95C3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/NotificationBanner/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.dh.NotificationBanner;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		823255951EB872AB006F95C3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/NotificationBanner/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.dh.NotificationBanner;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		823255851EB872AB006F95C3 /* Build configuration list for PBXProject "NotificationBanner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				823255911EB872AB006F95C3 /* Debug */,
+				823255921EB872AB006F95C3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		823255931EB872AB006F95C3 /* Build configuration list for PBXNativeTarget "NotificationBanner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				823255941EB872AB006F95C3 /* Debug */,
+				823255951EB872AB006F95C3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 823255821EB872AB006F95C3 /* Project object */;
+}

--- a/NotificationBanner.xcodeproj/project.pbxproj
+++ b/NotificationBanner.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/NotificationBanner/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dh.NotificationBanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -330,6 +331,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/NotificationBanner/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dh.NotificationBanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/NotificationBanner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/NotificationBanner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:NotificationBanner.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/NotificationBanner.xcodeproj/xcshareddata/xcschemes/NotificationBanner.xcscheme
+++ b/NotificationBanner.xcodeproj/xcshareddata/xcschemes/NotificationBanner.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8232558A1EB872AB006F95C3"
+               BuildableName = "NotificationBanner.framework"
+               BlueprintName = "NotificationBanner"
+               ReferencedContainer = "container:NotificationBanner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8232558A1EB872AB006F95C3"
+            BuildableName = "NotificationBanner.framework"
+            BlueprintName = "NotificationBanner"
+            ReferencedContainer = "container:NotificationBanner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8232558A1EB872AB006F95C3"
+            BuildableName = "NotificationBanner.framework"
+            BlueprintName = "NotificationBanner"
+            ReferencedContainer = "container:NotificationBanner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -17,7 +17,7 @@
  */
 
 import UIKit
-import MarqueeLabel
+import MarqueeLabelSwift
 
 public class BaseNotificationBanner: UIView {
     

--- a/NotificationBanner/Classes/NotificationBanner.swift
+++ b/NotificationBanner/Classes/NotificationBanner.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 import SnapKit
-import MarqueeLabel
+import MarqueeLabelSwift
 
 public class NotificationBanner: BaseNotificationBanner {
     

--- a/NotificationBanner/Classes/StatusBarNotificationBanner.swift
+++ b/NotificationBanner/Classes/StatusBarNotificationBanner.swift
@@ -17,7 +17,7 @@
  */
 
 import UIKit
-import MarqueeLabel
+import MarqueeLabelSwift
 
 public class StatusBarNotificationBanner: BaseNotificationBanner {
     

--- a/NotificationBanner/Supporting Files/Info.plist
+++ b/NotificationBanner/Supporting Files/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/NotificationBanner/Supporting Files/NotificationBanner.h
+++ b/NotificationBanner/Supporting Files/NotificationBanner.h
@@ -1,0 +1,19 @@
+//
+//  NotificationBanner.h
+//  NotificationBanner
+//
+//  Created by Cihat Gündüz on 02.05.17.
+//  Copyright © 2017 Dalton Hinterscher. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for NotificationBanner.
+FOUNDATION_EXPORT double NotificationBannerVersionNumber;
+
+//! Project version string for NotificationBanner.
+FOUNDATION_EXPORT const unsigned char NotificationBannerVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <NotificationBanner/PublicHeader.h>
+
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Version](https://img.shields.io/cocoapods/v/NotificationBannerSwift.svg?style=flat)](http://cocoapods.org/pods/NotificationBannerSwift)
 [![Platform](https://img.shields.io/cocoapods/p/NotificationBannerSwift.svg?style=flat)](http://cocoapods.org/pods/NotificationBannerSwift)
 <a href="https://developer.apple.com/swift"><img src="https://img.shields.io/badge/swift-3.0-4BC51D.svg?style=flat" alt="Language: Swift" /></a>
+![Carthage](https://img.shields.io/badge/Carthage-✓-5f7cae.svg?style=flat)
 [![License](https://img.shields.io/cocoapods/l/NotificationBannerSwift.svg?style=flat)](http://cocoapods.org/pods/NotificationBannerSwift)
 
 ## Written in Swift 3

--- a/README.md
+++ b/README.md
@@ -30,12 +30,24 @@ NotificationBanner is an extremely customizable and lightweight library that mak
 
 ## Installation
 
+### CocoaPods
+
 NotificationBanner is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
 pod 'NotificationBannerSwift'
 ```
+
+### Carthage
+
+To use NotificationBanner via Carthage simply add this line to your `Cartfile`:
+
+```swift
+github "Daltron/NotificationBanner" ~> 1.1
+```
+
+Then add `NotificationBanner.framework` and the dependencies `SnapKit.framework` and `MarqueeLabelSwift.framework` in your project.
 
 ## Usage
 
@@ -93,7 +105,7 @@ class CustomBannerColors: BannerColorsProtocol {
             case .warning:  // Your custom .warning color
         }
     }
-       
+
 }
 ```
 
@@ -121,7 +133,7 @@ banner.show()
 let rightView = UIImageView(image: #imageLiteral(resourceName: "danger"))
 let banner = NotificationBanner(title: title, subtitle: subtitle, rightView: rightView, style: .danger)
 banner.show()    
-        
+
 // Info Style Notification with Left and Right Views
 let leftView = UIImageView(image: #imageLiteral(resourceName: "info"))
 let rightView = UIImageView(image: #imageLiteral(resourceName: "right_chevron"))
@@ -166,7 +178,7 @@ By default, each notification banner is placed onto a `NotificationBannerQueue`.
 banner.show(queuePosition: .front)
 ```
 
-Adding a banner to the front of the queue will temporarily suspend the currently displayed banner (if there is one) and will resume it after the banner in front of it dismisses. 
+Adding a banner to the front of the queue will temporarily suspend the currently displayed banner (if there is one) and will resume it after the banner in front of it dismisses.
 
 To get the number of banners currently on the queue, simply:
 


### PR DESCRIPTION
This adds Carthage compatibility and therefore fixes #4.
I also added a section in the README. Note that a new release must be made until a stable version of this library can be installed via Carthage the way explained in the README (the recommended way).

Unfortunately I had to change the `import` statements in the files for `MarqueeLabel` since the guys over there have [this issue](https://github.com/cbpowell/MarqueeLabel/issues/181) around. Until it is fixed I suggest you merge this into a branch named "carthage" (or alike) and update the README to state: `github "Daltron/NotificationBanner" "carthage"` instead of the variant with the version at the end.