### PR TITLE
Feature Requests from JoniVR

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -45,6 +45,9 @@ public class BaseNotificationBanner: UIView {
     
     /// Closure that will be executed if the notification banner is swiped up
     public var onSwipeUp: (() -> Void)?
+    
+    /// Wether or not the notification banner is currently being displayed
+    public private(set) var isDisplaying: Bool = false
 
     /// The view that the notification layout is presented on. The constraints/frame of this should not be changed
     internal var contentView: UIView!
@@ -56,7 +59,7 @@ public class BaseNotificationBanner: UIView {
     var isSuspended: Bool = false
     
     /// Responsible for positioning and auto managing notification banners
-    private let bannerQueue: NotificationBannerQueue = NotificationBannerQueue.sharedInstance
+    private let bannerQueue: NotificationBannerQueue = NotificationBannerQueue.default
     
     /// The main window of the application which banner views are placed on
     private let APP_WINDOW: UIWindow = UIApplication.shared.delegate!.window!!
@@ -126,6 +129,7 @@ public class BaseNotificationBanner: UIView {
             self.frame = CGRect(x: 0, y: -self.frame.height, width: self.frame.width, height: self.frame.height)
         }) { (completed) in
             self.removeFromSuperview()
+            self.isDisplaying = false
             self.bannerQueue.showNext(onEmpty: {
                 self.APP_WINDOW.windowLevel = UIWindowLevelNormal
             })
@@ -157,6 +161,7 @@ public class BaseNotificationBanner: UIView {
             UIView.animate(withDuration: 0.5, delay: 0.0, usingSpringWithDamping: 0.7, initialSpringVelocity: 1, options: .curveLinear, animations: {
                 self.frame = CGRect(x: 0, y: 0, width: self.frame.width, height: self.frame.height)
             }) { (completed) in
+                self.isDisplaying = true
                 let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.onTapGestureRecognizer))
                 self.addGestureRecognizer(tapGestureRecognizer)
                 
@@ -174,6 +179,7 @@ public class BaseNotificationBanner: UIView {
     func suspend() {
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(dismiss), object: nil)
         isSuspended = true
+        isDisplaying = false
     }
     
     /**
@@ -182,6 +188,7 @@ public class BaseNotificationBanner: UIView {
     func resume() {
         self.perform(#selector(dismiss), with: nil, afterDelay: self.duration)
         isSuspended = false
+        isDisplaying = true
     }
     
     /**

--- a/NotificationBanner/Classes/NotificationBannerQueue.swift
+++ b/NotificationBanner/Classes/NotificationBannerQueue.swift
@@ -23,19 +23,18 @@ public enum QueuePosition {
     case front
 }
 
-class NotificationBannerQueue: NSObject {
+public class NotificationBannerQueue: NSObject {
     
-    private static var sInstance: NotificationBannerQueue?
-    static var sharedInstance: NotificationBannerQueue {
-        guard let sInstance = sInstance else {
-            self.sInstance = NotificationBannerQueue()
-            return self.sInstance!
-        }
-        
-        return sInstance
-    }
-
+    /// The default instance of the NotificationBannerQueue
+    public static let `default` = NotificationBannerQueue()
+    
+    /// The notification banners currently placed on the queue
     private var banners: [BaseNotificationBanner] = []
+    
+    /// The current number of notification banners on the queue
+    public var numberOfBanners: Int {
+        return banners.count
+    }
     
     /**
         Adds a banner to the queue

--- a/NotificationBannerSwift.podspec
+++ b/NotificationBannerSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'NotificationBannerSwift'
-    s.version          = '1.1.0'
+    s.version          = '1.2.0'
     s.summary          = 'The easiest way to display in app notification banners in iOS.'
 
     s.description      = <<-DESC

--- a/README.md
+++ b/README.md
@@ -168,11 +168,17 @@ banner.show(queuePosition: .front)
 
 Adding a banner to the front of the queue will temporarily suspend the currently displayed banner (if there is one) and will resume it after the banner in front of it dismisses. 
 
+To get the number of banners currently on the queue, simply:
+
+```swift
+let numberOfBanners = NotificationBannerQueue.default.numberOfBanners
+```
+
  <b>This is all automatically managed!</b>
 
 ## Feature Requests
 
-I'd love to know anything that you think NotificationBanner is missing. Open an issue and add the `feature request` label to it and I'll do everything I can to accomodate that request if it is in the library's best interest. 😄 
+I'd love to know anything that you think NotificationBanner is missing. Open an issue and I'll add the `feature request` label to it and I'll do everything I can to accomodate that request if it is in the library's best interest. 😄 
 
 ## Author
 


### PR DESCRIPTION
## Changes:

• NotificationBanner's now have a `isDisplaying` boolean property which will tell you wether or not the banner is currently being displayed.

• The `NotificationBannerQueue` is now a public class that can be accessed via:
```swift
let bannerQueue = NotificationBannerQueue.default
```
As of right now, the only thing that can be obtained from the banner queue is a property called `numberOfBanners` which tells you how many notification banners are currently on the queue.
##
New CocoaPods Release: v1.2.0 ✅ 
Closes #8 🎉 
Thanks @JoniVr! 👍 