### PR TITLE
Allow custom animation frames

### DIFF
--- a/Example/NotificationBanner/ExampleView.swift
+++ b/Example/NotificationBanner/ExampleView.swift
@@ -23,6 +23,7 @@ protocol ExampleViewDelegate : class {
 class ExampleView: UIView {
     
     weak var delegate: ExampleViewDelegate?
+    var queuePositionContentView: UIView!
     var queuePositionSegmentedControl: UISegmentedControl!
     var bannerPositionSegmentedControl: UISegmentedControl!
 
@@ -30,7 +31,7 @@ class ExampleView: UIView {
         super.init(frame: .zero)
         self.delegate = delegate
         
-        let queuePositionContentView = UIView()
+        queuePositionContentView = UIView()
         addSubview(queuePositionContentView)
         
         let queuePositionSegmentLabel = UILabel()

--- a/Example/NotificationBanner/ExampleViewController.swift
+++ b/Example/NotificationBanner/ExampleViewController.swift
@@ -11,7 +11,7 @@ import NotificationBannerSwift
 
 class ExampleViewController: UIViewController {
     
-    private var exampleView: ExampleView!
+    fileprivate var exampleView: ExampleView!
     
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -122,7 +122,7 @@ extension ExampleViewController: ExampleViewDelegate {
             banner.delegate = self
             
             banner.onTap = {
-                self.showAlert(title: "Banner Notification Tapped", message: "")
+                self.showAlert(title: "Custom Warning Under/Over Notification Tapped", message: "")
             }
             
             banner.show(queuePosition: selectedQueuePosition(), bannerPosition: selectedBannerPosition(), on: self)
@@ -145,6 +145,33 @@ extension ExampleViewController: ExampleViewDelegate {
             }
             
             banner.show(queuePosition: selectedQueuePosition(), bannerPosition: selectedBannerPosition())
+        case 6:
+            // Warning with an offset
+            let banner = NotificationBanner(title: "Custom Warning Notification",
+                                            subtitle: "Displayed With a custom offset",
+                                            style: .warning)
+            banner.delegate = self
+            banner.backgroundColor = blockColor(at: IndexPath(row: 6, section: 0))
+            banner.onTap = {
+                self.showAlert(title: "Banner Notification Tapped", message: "")
+            }
+            
+            // Custom grow/shrink at offsets
+            let width = UIApplication.shared.delegate!.window!!.frame.width
+            // If from the top, let's animate downward (grow) from the bottom of the position controls view.
+            // If from the bottom, grow upwards similar to the Under/Over.
+            let startY = selectedBannerPosition() == .top
+                ? exampleView.queuePositionContentView.frame.maxY + UIApplication.shared.statusBarFrame.height
+                : view.frame.height;
+            let endY = selectedBannerPosition() == .top ? startY : startY - banner.bannerHeight
+            let startFrame = CGRect.init(x: 0, y: startY, width: width, height: 0)
+            let endFrame = CGRect.init(x: 0, y: endY, width: width, height: banner.bannerHeight)
+            
+            banner.bannerPositionFrame = BannerPositionFrame.init(bannerPosition: selectedBannerPosition(),
+                                                                  startFrame: startFrame,
+                                                                  endFrame: endFrame)
+            
+            banner.show(queuePosition: selectedQueuePosition(), bannerPosition: selectedBannerPosition(), on: self)
         default:
             return
         }
@@ -248,7 +275,7 @@ extension ExampleViewController: ExampleViewDelegate {
     internal func numberOfCells(for section: Int) -> Int {
         switch section {
         case 0:
-            return 6
+            return 7
         case 1:
             return 3
         case 2:
@@ -291,6 +318,8 @@ extension ExampleViewController: ExampleViewDelegate {
             return UIColor(red: 0.23, green: 0.60, blue: 0.85, alpha: 1.00)
         case 3:
             return UIColor(red: 1.00, green: 0.66, blue: 0.16, alpha: 1.00)
+        case 6:
+            return UIColor(red: 0.21, green: 0.81, blue: 0.08, alpha: 1.00)
         default:
             return UIColor(red: 0.54, green: 0.40, blue: 0.54, alpha: 1.00)
         }
@@ -311,6 +340,8 @@ extension ExampleViewController: ExampleViewDelegate {
                 return ("Custom Warning Notification", "Displayed Under/Over the Navigation/Tab Bar")
             case 5:
                 return ("Basic Notification", "Must Be Dismissed Manually")
+            case 6:
+                return ("Offset Notification", "Displayed with an offset into a view")
             default:
                 return ("", nil)
             }

--- a/NotificationBanner/Classes/BannerPositionFrame.swift
+++ b/NotificationBanner/Classes/BannerPositionFrame.swift
@@ -23,6 +23,11 @@ public enum BannerPosition {
     case top
 }
 
+public enum BannerFrameDirection {
+    case startFrame
+    case endFrame
+}
+
 public class BannerPositionFrame: NSObject {
     
     /// The position the notification banner should slide in from (default is .top)
@@ -48,6 +53,15 @@ public class BannerPositionFrame: NSObject {
         self.bannerPosition = bannerPosition
         self.startFrame = startFrame(for: bannerPosition, bannerWidth: bannerWidth, bannerHeight: bannerHeight, maxY: maxY)
         self.endFrame = endFrame(for: bannerPosition, bannerWidth: bannerWidth, bannerHeight: bannerHeight, maxY: maxY)
+    }
+    
+    /// - note: May call view.layoutIfNeeded() if the heights of the start/end frames are not the same
+    internal func updateFrame(for view: UIView, to: BannerFrameDirection) {
+        let frame: CGRect! = (to == .startFrame ? startFrame : endFrame)
+        view.frame = frame
+        if startFrame.height != endFrame.height {
+            view.layoutIfNeeded()
+        }
     }
     
     /**

--- a/NotificationBanner/Classes/BannerPositionFrame.swift
+++ b/NotificationBanner/Classes/BannerPositionFrame.swift
@@ -23,16 +23,29 @@ public enum BannerPosition {
     case top
 }
 
-class BannerPositionFrame: NSObject {
+public class BannerPositionFrame: NSObject {
     
+    /// The position the notification banner should slide in from (default is .top)
+    private(set) var bannerPosition: BannerPosition! = .top
     private(set) var startFrame: CGRect!
     private(set) var endFrame: CGRect!
 
-    init(bannerPosition: BannerPosition,
-         bannerWidth: CGFloat,
-         bannerHeight: CGFloat,
-         maxY: CGFloat) {
+    
+    public init(bannerPosition: BannerPosition,
+                startFrame: CGRect!,
+                endFrame: CGRect!) {
         super.init()
+        self.bannerPosition = bannerPosition
+        self.startFrame = startFrame
+        self.endFrame = endFrame
+    }
+    
+    public init(bannerPosition: BannerPosition,
+                bannerWidth: CGFloat,
+                bannerHeight: CGFloat,
+                maxY: CGFloat) {
+        super.init()
+        self.bannerPosition = bannerPosition
         self.startFrame = startFrame(for: bannerPosition, bannerWidth: bannerWidth, bannerHeight: bannerHeight, maxY: maxY)
         self.endFrame = endFrame(for: bannerPosition, bannerWidth: bannerWidth, bannerHeight: bannerHeight, maxY: maxY)
     }
@@ -73,9 +86,9 @@ class BannerPositionFrame: NSObject {
      if the bannerPosition is .bottom
      */
     private func endFrame(for bannerPosition: BannerPosition,
-                            bannerWidth: CGFloat,
-                            bannerHeight: CGFloat,
-                            maxY: CGFloat) -> CGRect {
+                          bannerWidth: CGFloat,
+                          bannerHeight: CGFloat,
+                          maxY: CGFloat) -> CGRect {
         switch bannerPosition {
         case .bottom:
             return CGRect(x: 0,

--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -223,7 +223,7 @@ public class BaseNotificationBanner: UIView {
                                                object: nil)
         delegate?.notificationBannerWillDisappear(self)
         UIView.animate(withDuration: dismissAnimationDuration, animations: {
-            self.frame = bannerPositionFrame.startFrame
+            bannerPositionFrame.updateFrame(for: self, to: .startFrame)
         }) { (completed) in
             self.removeFromSuperview()
             self.isDisplaying = false
@@ -267,8 +267,8 @@ public class BaseNotificationBanner: UIView {
         if placeOnQueue {
             bannerQueue.addBanner(self, queuePosition: queuePosition)
         } else {
-            self.frame = bannerPositionFrame.startFrame
-            
+            bannerPositionFrame.updateFrame(for: self, to: .startFrame)
+
             if let parentViewController = parentViewController {
                 parentViewController.view.addSubview(self)
                 if statusBarShouldBeShown() {
@@ -290,7 +290,7 @@ public class BaseNotificationBanner: UIView {
                            options: .curveLinear,
                            animations: {
                             BannerHapticGenerator.generate(self.haptic)
-                            self.frame = bannerPositionFrame.endFrame
+                            bannerPositionFrame.updateFrame(for: self, to: .endFrame)
             }) { (completed) in
                 self.delegate?.notificationBannerDidAppear(self)
                 self.isDisplaying = true

--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -98,11 +98,22 @@ public class BaseNotificationBanner: UIView {
     /// The view controller to display the banner on. This is useful if you are wanting to display a banner underneath a navigation bar
     private weak var parentViewController: UIViewController?
     
-    /// The position the notification banner should slide in from
-    private(set) var bannerPosition: BannerPosition!
+    /// The position the notification banner should slide in from (default is .top)
+    /// - note: This is a read only property - either use the `show()` method, or create/assign the `bannerPositionFrame`
+    public var bannerPosition: BannerPosition! {
+        // Note - bannerPosition is now fully held inside bannerPositionFrame, so we just delgate to that.
+        return self.bannerPositionFrame?.bannerPosition ?? .top
+    }
     
     /// Object that stores the start and end frames for the notification banner based on the provided banner position
-    private var bannerPositionFrame: BannerPositionFrame!
+    /// - note: Constraints for internal views will be created on `didSet`
+    var bannerPositionFrame: BannerPositionFrame? {
+        didSet {
+            if let bannerPositionFrame = bannerPositionFrame {
+                createBannerConstraints(for: bannerPositionFrame.bannerPosition)
+            }
+        }
+    }
     
     public override var backgroundColor: UIColor? {
         get {
@@ -120,6 +131,7 @@ public class BaseNotificationBanner: UIView {
         addSubview(spacerView)
         
         contentView = UIView()
+        contentView.clipsToBounds = true
         addSubview(contentView)
         
         if let colors = colors {
@@ -151,7 +163,6 @@ public class BaseNotificationBanner: UIView {
     /**
         Creates the proper banner constraints based on the desired banner position
      */
-    
     private func createBannerConstraints(for bannerPosition: BannerPosition) {
         
         spacerView.snp.remakeConstraints { (make) in
@@ -176,19 +187,37 @@ public class BaseNotificationBanner: UIView {
             make.left.equalToSuperview()
             make.right.equalToSuperview()
         }
-
+    }
+    
+    /**
+        Creates and stores the BannerPositionFrame variable *only* if it is `nil`, otherwise simply returns existing variable.
+        - note: Also stores the `bannerPosition` varible *only* when creating/storing.
+     */
+    private func createBannerPositionFrameIfNecessary(bannerPosition: BannerPosition) -> BannerPositionFrame! {
+        if let bannerPositionFrame = bannerPositionFrame {
+            return bannerPositionFrame
+        }
+        // note the didSet on the variable assignment will call createBannerConstraints for us.
+        bannerPositionFrame = BannerPositionFrame(bannerPosition: bannerPosition,
+                                                  bannerWidth: appWindow.frame.width,
+                                                  bannerHeight: bannerHeight,
+                                                  maxY: maximumYPosition())
+        return bannerPositionFrame!
     }
     
     /**
         Dismisses the NotificationBanner and shows the next one if there is one to show on the queue
     */
     public func dismiss() {
+        guard let bannerPositionFrame = bannerPositionFrame
+            else { return }
+        
         NSObject.cancelPreviousPerformRequests(withTarget: self,
                                                selector: #selector(dismiss),
                                                object: nil)
         delegate?.notificationBannerWillDisappear(self)
         UIView.animate(withDuration: 0.5, animations: {
-            self.frame = self.bannerPositionFrame.startFrame
+            self.frame = bannerPositionFrame.startFrame
         }) { (completed) in
             self.removeFromSuperview()
             self.isDisplaying = false
@@ -205,9 +234,9 @@ public class BaseNotificationBanner: UIView {
         Places a NotificationBanner on the queue and shows it if its the first one in the queue
         - parameter queuePosition: The position to show the notification banner. If the position is .front, the
         banner will be displayed immediately
+        - parameter bannerPosition: If `bannerPositionFrame` is `nil`, the position the notification banner should slide in from, ignored otherwise
         - parameter viewController: The view controller to display the notifification banner on. If nil, it will
         be placed on the main app window
-        - parameter bannerPosition: The position the notification banner should slide in from
     */
     public func show(queuePosition: QueuePosition = .back,
                      bannerPosition: BannerPosition = .top,
@@ -227,14 +256,7 @@ public class BaseNotificationBanner: UIView {
               queuePosition: QueuePosition = .back,
               bannerPosition: BannerPosition = .top) {
         
-        if bannerPositionFrame == nil {
-            self.bannerPosition = bannerPosition
-            createBannerConstraints(for: bannerPosition)
-            bannerPositionFrame = BannerPositionFrame(bannerPosition: bannerPosition,
-                                                      bannerWidth: appWindow.frame.width,
-                                                      bannerHeight: bannerHeight,
-                                                      maxY: maximumYPosition())
-        }
+        let bannerPositionFrame: BannerPositionFrame! = createBannerPositionFrameIfNecessary(bannerPosition: bannerPosition)
         
         if placeOnQueue {
             bannerQueue.addBanner(self, queuePosition: queuePosition)
@@ -262,7 +284,7 @@ public class BaseNotificationBanner: UIView {
                            options: .curveLinear,
                            animations: {
                             BannerHapticGenerator.generate(self.haptic)
-                            self.frame = self.bannerPositionFrame.endFrame
+                            self.frame = bannerPositionFrame.endFrame
             }) { (completed) in
                 self.delegate?.notificationBannerDidAppear(self)
                 self.isDisplaying = true

--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -107,7 +107,7 @@ public class BaseNotificationBanner: UIView {
     
     /// Object that stores the start and end frames for the notification banner based on the provided banner position
     /// - note: Constraints for internal views will be created on `didSet`
-    var bannerPositionFrame: BannerPositionFrame? {
+    public var bannerPositionFrame: BannerPositionFrame? {
         didSet {
             if let bannerPositionFrame = bannerPositionFrame {
                 createBannerConstraints(for: bannerPositionFrame.bannerPosition)

--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -42,12 +42,18 @@ public class BaseNotificationBanner: UIView {
     /// The topmost label of the notification if a custom view is not desired
     public internal(set) var titleLabel: MarqueeLabel?
     
-    /// The time before the notificaiton is automatically dismissed
+    /// The time before the notification is automatically dismissed
     public var duration: TimeInterval = 5.0 {
         didSet {
             updateMarqueeLabelsDurations()
         }
     }
+    
+    /// The amount of time to animate showing the banner onto the view
+    public var showAnimationDuration = 0.5
+
+    /// The amount of time to animate hiding the banner away
+    public var dismissAnimationDuration = 0.5
     
     /// If false, the banner will not be dismissed until the developer programatically dismisses it
     public var autoDismiss: Bool = true {
@@ -216,7 +222,7 @@ public class BaseNotificationBanner: UIView {
                                                selector: #selector(dismiss),
                                                object: nil)
         delegate?.notificationBannerWillDisappear(self)
-        UIView.animate(withDuration: 0.5, animations: {
+        UIView.animate(withDuration: dismissAnimationDuration, animations: {
             self.frame = bannerPositionFrame.startFrame
         }) { (completed) in
             self.removeFromSuperview()
@@ -277,7 +283,7 @@ public class BaseNotificationBanner: UIView {
                 }
             }
             delegate?.notificationBannerWillAppear(self)
-            UIView.animate(withDuration: 0.5,
+            UIView.animate(withDuration: showAnimationDuration,
                            delay: 0.0,
                            usingSpringWithDamping: 0.7,
                            initialSpringVelocity: 1,

--- a/NotificationBannerSwift.podspec
+++ b/NotificationBannerSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'NotificationBannerSwift'
-    s.version          = '1.4.0'
+    s.version          = '1.5'
     s.summary          = 'The easiest way to display in app notification banners in iOS.'
 
     s.description      = <<-DESC


### PR DESCRIPTION
Very likely a rare use case: the need to animate a banner below (or above) an existing element on your view. In my case, this was for Issue #37 (see for mockup picture too). 

Rather than limit to a `CGFloat` of an offset, I exposed the most-excellent `BannerPositionFrame` which has a `startFrame` and an `endFrame` - so you can have even more interesting possibilities (explode from pixel point, for example).

I did take unasked-for liberties with some internal variables - I moved the `bannerPosition` into the `bannerPositionFrame` proper, and made the latter an optional. This guards against a crash when an incredibly silly developer might call `dismiss()` on a banner s/he had not `show()`n - though this developer has no idea how _that_ person could continue to show their face. Regardless.