### PR TITLE
Update SnapKit Version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -2,4 +2,4 @@
 github "cbpowell/MarqueeLabel" ~> 3.0
 
 # A Swift Autolayout DSL for iOS & OS X
-github "SnapKit/SnapKit" ~> 3.2
+github "SnapKit/SnapKit" ~> 4.0.0


### PR DESCRIPTION
#### Description 
* Updated snapkit version. 

### Details
* Carthage was attempting to download version 3.2 of snap kit, so it could never download the latest version of snapkit. 

* Tested on my own fork and ran Carthage update and made sure that alert was working properly. 

Please Review. 
