### PR TITLE
Fix MarqueeLabel swift 4 and swift 4.2 issue 

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 # A scolling drop-in replacement for UILabel for long texts.
-github "cbpowell/MarqueeLabel" ~> 3.0
+github "cbpowell/MarqueeLabel"
 
 # A Swift Autolayout DSL for iOS & OS X
 github "SnapKit/SnapKit" ~> 4.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "cbpowell/MarqueeLabel" "3.0.5"
+github "cbpowell/MarqueeLabel"
 github "SnapKit/SnapKit" "3.2.0"

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -11,14 +11,3 @@ target 'NotificationBanner_Example' do
 
   end
 end
-
-post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        swift4_projects = ['MarqueeLabel']
-        if swift4_projects.include? target.name
-            target.build_configurations.each do |config|
-                config.build_settings['SWIFT_VERSION'] = '4.0'
-            end
-        end
-    end
-end


### PR DESCRIPTION
remove unneeded code in PodFile that broke installing of MarqueeLabel 3.2.0 (Swift 4.2) and installing only version with Swift 4

___
There was an issue when u install the 
pod 'NotificationBannerSwift'
 
but MarqueeLabel framework is on swift 4 and the project can't be build and so, u can't use it 

MarqueeLabel  v3.0 - is an old version with swift 4 and the new one is = v3.2.0 with swift 4.2 

Fix is in pod spec and pod file 