### PR TITLE
Add function to reset a banner's elapsed duration to zero

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -397,6 +397,16 @@ public class BaseNotificationBanner: UIView {
             isDisplaying = true
         }
     }
+ 
+    /**
+        Resets a notification banner's elapsed duration to zero.
+    */
+    public func resetDuration() {
+        if autoDismiss {
+             NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(dismiss), object: nil)
+             self.perform(#selector(dismiss), with: nil, afterDelay: self.duration)
+        }
+    }
     
     /**
         Changes the frame of the notification banner when the orientation of the device changes


### PR DESCRIPTION
This can be useful if you don't want the banner to dismiss after the normal duration because you updated the content of a banner.

For example, if a banner's duration is 5 seconds and it has been displayed for 4 seconds so far, calling this function once will make the banner display for a total of 9 seconds (4 + 5).