### PR TITLE
Use MarqueeLabel instead of MarqueeLabelSwift for Carthage builds

### DIFF
--- a/NotificationBanner.xcodeproj/project.pbxproj
+++ b/NotificationBanner.xcodeproj/project.pbxproj
@@ -365,7 +365,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_SWIFT_FLAGS = "-DCARTHAGE_CONFIG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dh.NotificationBanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -389,7 +388,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_SWIFT_FLAGS = "-DCARTHAGE_CONFIG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dh.NotificationBanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -19,11 +19,7 @@
 import UIKit
 import SnapKit
 
-#if CARTHAGE_CONFIG
-    import MarqueeLabelSwift
-#else
-    import MarqueeLabel
-#endif
+import MarqueeLabel
 
 public protocol NotificationBannerDelegate: class {
     func notificationBannerWillAppear(_ banner: BaseNotificationBanner)

--- a/NotificationBanner/Classes/NotificationBanner.swift
+++ b/NotificationBanner/Classes/NotificationBanner.swift
@@ -19,11 +19,7 @@
 import UIKit
 import SnapKit
 
-#if CARTHAGE_CONFIG
-    import MarqueeLabelSwift
-#else
-    import MarqueeLabel
-#endif
+import MarqueeLabel
 
 @objcMembers
 public class NotificationBanner: BaseNotificationBanner {

--- a/NotificationBanner/Classes/StatusBarNotificationBanner.swift
+++ b/NotificationBanner/Classes/StatusBarNotificationBanner.swift
@@ -18,11 +18,7 @@
 
 import UIKit
 
-#if CARTHAGE_CONFIG
-    import MarqueeLabelSwift
-#else
-    import MarqueeLabel
-#endif
+import MarqueeLabel
 
 @objcMembers
 public class StatusBarNotificationBanner: BaseNotificationBanner {

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To use NotificationBanner via Carthage simply add this line to your `Cartfile`:
 github "Daltron/NotificationBanner" "master"
 ```
 
-Then add `NotificationBanner.framework` and the dependencies `SnapKit.framework` and `MarqueeLabelSwift.framework` in your project.
+Then add `NotificationBanner.framework` and the dependencies `SnapKit.framework` and `MarqueeLabel.framework` in your project.
 
 ## Usage
 


### PR DESCRIPTION
After 4.0.0 MarqueeLabelSwift has been deprecated for Swift 5 releases and replaced with MarqueeLabel.

Removing the MarqueeLabelSwift import for Carthage builds should fix the build errors for the NotificationBanner framework.

Fixes #206