### PR TITLE
Tweaked Apps that Use NotificationBanner Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,12 +289,12 @@ I'd love to know anything that you think NotificationBanner is missing. Open an 
 
 ## Apps that Use NotificationBanner
 [![Q - Talk About Music](AppIcons/q_talk_about_music.jpg)](https://itunes.apple.com/us/app/q-talk-about-music/id1071551321?mt=8) 
-[![VH Dispatch](AppIcons/vh_dispatch.png)](https://apps.apple.com/us/app/vh-dispatch/id1249569084?mt=8)
-[![Stikkr](AppIcons/stikkr.png)](https://apps.apple.com/us/app/stikkr/id851375015?ls=1&mt=8)
-[![CardCast](AppIcons/cardcast.png)](https://apps.apple.com/us/app/cardcast-business-cards/id1269278947?mt=8)
-[![Happy Scale](AppIcons/happy_scale.png)](https://apps.apple.com/us/app/happy-scale/id532430574?mt=8)
-[![Wanderings](AppIcons/wanderings.png)](https://apps.apple.com/us/app/wanderings-travel-tracking/id1292503352?mt=8)
-[![Modern Magic 8 Ball](AppIcons/modernmagic8ball.png)](https://apps.apple.com/us/app/modern-magic-8-ball/id1381145384?mt=8)
+[![VH Dispatch](AppIcons/vh_dispatch.png)](https://apps.apple.com/app/vh-dispatch/id1249569084)
+[![Stikkr](AppIcons/stikkr.png)](https://apps.apple.com/app/stikkr/id851375015)
+[![CardCast](AppIcons/cardcast.png)](https://apps.apple.com/app/cardcast-business-cards/id1269278947)
+[![Happy Scale](AppIcons/happy_scale.png)](https://apps.apple.com/app/happy-scale/id532430574)
+[![Wanderings](AppIcons/wanderings.png)](https://apps.apple.com/app/wanderings-travel-tracking/id1292503352)
+[![Modern Magic 8 Ball](AppIcons/modernmagic8ball.png)](https://apps.apple.com/app/modern-magic-8-ball/id1381145384)
  
 #### Feel free to add yours!
 

--- a/README.md
+++ b/README.md
@@ -289,12 +289,12 @@ I'd love to know anything that you think NotificationBanner is missing. Open an 
 
 ## Apps that Use NotificationBanner
 [![Q - Talk About Music](AppIcons/q_talk_about_music.jpg)](https://itunes.apple.com/us/app/q-talk-about-music/id1071551321?mt=8) 
-[![VH Dispatch](AppIcons/vh_dispatch.png)](https://itunes.apple.com/us/app/vh-dispatch/id1249569084?mt=8)
-[![Stikkr](AppIcons/stikkr.png)](https://itunes.apple.com/us/app/stikkr/id851375015?ls=1&mt=8)
-[![CardCast](AppIcons/cardcast.png)](https://itunes.apple.com/us/app/cardcast-business-cards/id1269278947?mt=8)
-[![Happy Scale](AppIcons/happy_scale.png)](https://itunes.apple.com/us/app/happy-scale/id532430574?mt=8)
-[![Wanderings](AppIcons/wanderings.png)](https://itunes.apple.com/us/app/wanderings-travel-tracking/id1292503352?mt=8)
-[![Modern Magic 8 Ball](AppIcons/modernmagic8ball.png)](https://itunes.apple.com/us/app/modern-magic-8-ball/id1381145384?mt=8)
+[![VH Dispatch](AppIcons/vh_dispatch.png)](https://apps.apple.com/us/app/vh-dispatch/id1249569084?mt=8)
+[![Stikkr](AppIcons/stikkr.png)](https://apps.apple.com/us/app/stikkr/id851375015?ls=1&mt=8)
+[![CardCast](AppIcons/cardcast.png)](https://apps.apple.com/us/app/cardcast-business-cards/id1269278947?mt=8)
+[![Happy Scale](AppIcons/happy_scale.png)](https://apps.apple.com/us/app/happy-scale/id532430574?mt=8)
+[![Wanderings](AppIcons/wanderings.png)](https://apps.apple.com/us/app/wanderings-travel-tracking/id1292503352?mt=8)
+[![Modern Magic 8 Ball](AppIcons/modernmagic8ball.png)](https://apps.apple.com/us/app/modern-magic-8-ball/id1381145384?mt=8)
  
 #### Feel free to add yours!
 


### PR DESCRIPTION
Changed itunes.apple.com to apps.apple.com, apple just redirects you with the apps.apple.com from itunes.apple.com URL now. This saves a redirect.