### PR TITLE
Fix overlapping of GrowingNotificationBanner with status bar on iOS 13 for non-notch devices

### DIFF
--- a/NotificationBanner/Classes/GrowingNotificationBanner.swift
+++ b/NotificationBanner/Classes/GrowingNotificationBanner.swift
@@ -70,7 +70,7 @@ open class GrowingNotificationBanner: BaseNotificationBanner {
                     actualBannerHeight += innerSpacing
                 }
                 
-                return max(actualBannerHeight, minHeight)
+                return statusBarHeightAdjustment + max(actualBannerHeight, minHeight)
             }
         } set {
             customBannerHeight = newValue
@@ -180,6 +180,19 @@ open class GrowingNotificationBanner: BaseNotificationBanner {
     
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+
+    private var statusBarHeightAdjustment: CGFloat {
+        guard #available(iOS 13.0, *), !NotificationBannerUtilities.isNotchFeaturedIPhone() else {
+            return 0
+        }
+
+        return UIApplication.shared.statusBarFrame.height
+    }
+
+    override func spacerViewHeight() -> CGFloat {
+        return super.spacerViewHeight() + statusBarHeightAdjustment
     }
 }
 


### PR DESCRIPTION
Similar to #240 but for `GrowingNotificationBanner`, the spacing between the status bar and `titleLabel` are too small and visually broken.

Current behavior:
![image](https://user-images.githubusercontent.com/2691371/66217559-d6e93980-e6c7-11e9-97a4-b0c65f8dc38d.png)

Fixed behavior:
![image](https://user-images.githubusercontent.com/2691371/66217605-e8cadc80-e6c7-11e9-85f8-00437bdc5180.png)
