### PR TITLE
Fix zero blur radius usage for Floating Notifications banners

### DIFF
--- a/NotificationBanner/Classes/FloatingNotificationBanner.swift
+++ b/NotificationBanner/Classes/FloatingNotificationBanner.swift
@@ -133,7 +133,9 @@ private extension FloatingNotificationBanner {
                              cornerRadius: CGFloat = 0,
                              offset: UIOffset = .zero,
                              edgeInsets: UIEdgeInsets? = nil) {
-        guard blurRadius > 0 else { return }
+
+        guard blurRadius >= 0 else { return }
+
         contentView.layer.shadowColor = color.cgColor
         contentView.layer.shadowOpacity = Float(opacity)
         contentView.layer.shadowRadius = blurRadius


### PR DESCRIPTION
Trivial fix #237 