### PR TITLE
Changed selected window for presenting banners

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -151,7 +151,7 @@ open class BaseNotificationBanner: UIView {
             return UIApplication.shared.connectedScenes
                 .first { $0.activationState == .foregroundActive }
                 .map { $0 as? UIWindowScene }
-                .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? nil
+                .map { $0?.windows.last } ?? UIApplication.shared.delegate?.window ?? nil
         }
         
         return UIApplication.shared.delegate?.window ?? nil


### PR DESCRIPTION
On iOS 13 the default method show() without parameters does not work to present the NotificationBanner on top of the current screen since the first window of the UIWindowScene was used. Therefore, I changed it to use the last window and it should work now correctly again.