### PR TITLE
set BUILD_LIBRARY_FOR_DISTRIBUTION to YES

### DIFF
--- a/NotificationBanner.xcodeproj/project.pbxproj
+++ b/NotificationBanner.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 		823255941EB872AB006F95C3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -379,6 +380,7 @@
 		823255951EB872AB006F95C3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
To fix the error of `module compiled with Swift 5.1 cannot be imported by the Swift 5.1.2 compiler`
for Xcode 11.2