### PR TITLE
Propagate bannerPosition for enqueued banners

### DIFF
--- a/NotificationBanner/Classes/NotificationBannerQueue.swift
+++ b/NotificationBanner/Classes/NotificationBannerQueue.swift
@@ -104,7 +104,7 @@ open class NotificationBannerQueue: NSObject {
             if banner.isSuspended {
                 banner.resume()
             } else {
-                banner.show(placeOnQueue: false)
+                banner.show(placeOnQueue: false, bannerPosition: banner.bannerPosition)
             }
 
             callback(false)


### PR DESCRIPTION
At the moment when a banner is enqueued it doesn't retain the position and it is always being shown at the top.