### PR TITLE
Change key window finding logic

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -151,10 +151,7 @@ open class BaseNotificationBanner: UIView {
     /// The main window of the application which banner views are placed on
     private let appWindow: UIWindow? = {
         if #available(iOS 13.0, *) {
-            return UIApplication.shared.connectedScenes
-                .first { $0.activationState == .foregroundActive }
-                .map { $0 as? UIWindowScene }
-                .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? nil
+            return UIApplication.shared.windows.filter { $0.isKeyWindow }.first ?? UIApplication.shared.delegate?.window ?? nil
         }
 
         return UIApplication.shared.delegate?.window ?? nil


### PR DESCRIPTION
In the project I'm working on, we're getting random crashes related to `connectedScenes`:
Fatal Exception: NSInvalidArgumentException
-[UIApplication connectedScenes]: unrecognized selector sent to instance *someInstance*

I couldn't reproduce this, but we have over 800 crashes from this in the past month. I've researched this property a bit, and it seems that just filtering the key window should be enough without using `connectedScenes` property. I have no idea though why UIApplication can't find this method signature sometimes.

Any thoughts?

