### PR TITLE
Fixed nil UIWindow on IOS 12 

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -157,7 +157,7 @@ open class BaseNotificationBanner: UIView {
                 .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? nil
         }
 
-        return UIApplication.shared.delegate?.window ?? nil
+        return UIApplication.shared.delegate?.window ?? UIApplication.shared.keyWindow
     }()
 
     /// The position the notification banner should slide in from


### PR DESCRIPTION
Now NotificationBanner can handle the UIWindow main instance by the keyWindow.