### PR TITLE
Limit front queue count

### DIFF
--- a/NotificationBanner/Classes/NotificationBannerQueue.swift
+++ b/NotificationBanner/Classes/NotificationBannerQueue.swift
@@ -54,25 +54,20 @@ open class NotificationBannerQueue: NSObject {
     func addBanner(_ banner: BaseNotificationBanner,
                    bannerPosition: BannerPosition,
                    queuePosition: QueuePosition) {
-
+        let bannersCount =  banners.filter { $0.isDisplaying }.count
         if queuePosition == .back {
             banners.append(banner)
-
-            let bannersCount =  banners.filter { $0.isDisplaying }.count
             if bannersCount < maxBannersOnScreenSimultaneously {
                 banner.show(placeOnQueue: false, bannerPosition: banner.bannerPosition)
             }
-
         } else {
-            banner.show(placeOnQueue: false, bannerPosition: bannerPosition)
-
-            if let firstBanner = firstNotDisplayedBanner() {
-                firstBanner.suspend()
+            if bannersCount >= maxBannersOnScreenSimultaneously {
+                banners.first?.suspend()
             }
 
+            banner.show(placeOnQueue: false, bannerPosition: bannerPosition)
             banners.insert(banner, at: 0)
         }
-
     }
 
     /**


### PR DESCRIPTION
This is a fix for #253 

Basically:

1. The `maxBannersOnScreenSimultaneously` setting should also apply to the front queue position.
2. Suspend the `firstNotDisplayedBanner` is doing nothing (I guess?). We need to suspend the first (current shown) banner instead, so it can continue after this newly added front queue banner being dismissed.