### PR TITLE
fix: unwrap of nil bannerPositionFrame on iOS 13+

### DIFF
--- a/NotificationBanner/Classes/FloatingNotificationBanner.swift
+++ b/NotificationBanner/Classes/FloatingNotificationBanner.swift
@@ -141,7 +141,7 @@ private extension FloatingNotificationBanner {
         contentView.layer.shadowRadius = blurRadius
         contentView.layer.shadowOffset = CGSize(width: offset.horizontal, height: offset.vertical)
         
-        if let edgeInsets = edgeInsets {
+        if let edgeInsets = edgeInsets, let bannerPositionFrame = bannerPositionFrame {
             var shadowRect = CGRect(origin: .zero, size: bannerPositionFrame.startFrame.size)
             shadowRect.size.height -= (spacerViewHeight() - spacerViewDefaultOffset) // to proper handle spacer height affects
             shadowRect.origin.x += edgeInsets.left


### PR DESCRIPTION
Due to the new Scene behavior in iOS 13 there are some cases where the `bannerPositionFrame` in `BaseNotificationBanner` may be nil.

This always leads to a fatal error.

### Proposed solution

The proposed solution is to change `bannerPositionFrame` from _implicitly unwrapped optional_ to _optional_ and force the code that deals with it to handle the case when the banner has no frame (e.g. because no Window is presented on screen).

---

Fixes #286