### PR TITLE
Add public initializer to BannerColors

### DIFF
--- a/NotificationBanner/Classes/BannerColors.swift
+++ b/NotificationBanner/Classes/BannerColors.swift
@@ -24,6 +24,8 @@ public protocol BannerColorsProtocol {
 }
 
 public class BannerColors: BannerColorsProtocol {
+ 
+    public init() { }
 
     public func color(for style: BannerStyle) -> UIColor {
         switch style {


### PR DESCRIPTION
To enable clients to do something like this:

```
class EventLogColors: BannerColorsProtocol {
    
    private let defaults: BannerColors
    
    init(defaults: BannerColors = BannerColors()) {
        self.defaults = defaults
    }
    
    func color(for style: BannerStyle) -> UIColor {
        switch style {
        case .info:
            return .myCustomInfoColor
        case .danger:
            return .myCustomDangerColor
        default:
            return defaults.color(for: style)
        }
    }
    
}

```