### PR TITLE
Hotfix: bannerPositionFrame.startFrame unwrapping crash 

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -155,6 +155,9 @@ open class BaseNotificationBanner: UIView {
                 .first { $0.activationState == .foregroundActive }
                 .map { $0 as? UIWindowScene }
                 .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? nil
+        } else {
+            let windows = UIApplication.shared.windows
+            return windows.count > 0 ? windows.first : nil
         }
 
         return UIApplication.shared.delegate?.window ?? nil

--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -155,12 +155,10 @@ open class BaseNotificationBanner: UIView {
                 .first { $0.activationState == .foregroundActive }
                 .map { $0 as? UIWindowScene }
                 .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? nil
-        } else {
-            let windows = UIApplication.shared.windows
-            return windows.count > 0 ? windows.first : nil
         }
-
-        return UIApplication.shared.delegate?.window ?? nil
+        
+        let windows = UIApplication.shared.windows
+        return windows.count > 0 ? windows.first : nil
     }()
 
     /// The position the notification banner should slide in from


### PR DESCRIPTION
Fixes #286 

Issue was being caused in 
```
private let appWindow: UIWindow? = {
        if #available(iOS 13.0, *) {
            return UIApplication.shared.connectedScenes
                .first { $0.activationState == .foregroundActive }
                .map { $0 as? UIWindowScene }
                .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? nil
        }

        return UIApplication.shared.delegate?.window ?? nil
    }()
```
Where the final return statement returns nil when UIApplication.shared.delegate?.window is also nil