### PR TITLE
Turk jk patch 309

### DIFF
--- a/NotificationBanner/Classes/FloatingNotificationBanner.swift
+++ b/NotificationBanner/Classes/FloatingNotificationBanner.swift
@@ -37,30 +37,36 @@ open class FloatingNotificationBanner: GrowingNotificationBanner {
 
         super.init(title: title, subtitle: subtitle, leftView: leftView, rightView: rightView, style: style, colors: colors, iconPosition: iconPosition)
         
-        if let titleFont = titleFont {
+        if let titleLabel = titleLabel,
+            let titleFont = titleFont {
             self.titleFont = titleFont
-            titleLabel!.font = titleFont
+            titleLabel.font = titleFont
         }
         
-        if let titleColor = titleColor {
-            titleLabel!.textColor = titleColor
+        if let titleColor = titleColor,
+            let titleLabel = titleLabel {
+            titleLabel.textColor = titleColor
         }
         
-        if let titleTextAlign = titleTextAlign {
-            titleLabel!.textAlignment = titleTextAlign
+        if let titleTextAlign = titleTextAlign,
+            let titleLabel = titleLabel {
+            titleLabel.textAlignment = titleTextAlign
         }
         
-        if let subtitleFont = subtitleFont {
+        if let subtitleFont = subtitleFont,
+            let subtitleLabel = subtitleLabel{
             self.subtitleFont = subtitleFont
-            subtitleLabel!.font = subtitleFont
+            subtitleLabel.font = subtitleFont
         }
         
-        if let subtitleColor = subtitleColor {
-            subtitleLabel!.textColor = subtitleColor
+        if let subtitleColor = subtitleColor,
+        let subtitleLabel = subtitleLabel {
+            subtitleLabel.textColor = subtitleColor
         }
         
-        if let subtitleTextAlign = subtitleTextAlign {
-            subtitleLabel!.textAlignment = subtitleTextAlign
+        if let subtitleTextAlign = subtitleTextAlign,
+        let subtitleLabel = subtitleLabel {
+            subtitleLabel.textAlignment = subtitleTextAlign
         }
     }
     

--- a/NotificationBanner/Classes/GrowingNotificationBanner.swift
+++ b/NotificationBanner/Classes/GrowingNotificationBanner.swift
@@ -201,30 +201,36 @@ public extension GrowingNotificationBanner {
             contentView.layer.cornerRadius = cornerRadius
         }
         
-        if let titleFont = titleFont {
+        if let titleFont = titleFont,
+            let titleLabel = titleLabel {
             self.titleFont = titleFont
-            titleLabel!.font = titleFont
+            titleLabel.font = titleFont
         }
         
-        if let titleColor = titleColor {
-            titleLabel!.textColor = titleColor
+        if let titleColor = titleColor,
+            let titleLabel = titleLabel {
+            titleLabel.textColor = titleColor
         }
         
-        if let titleTextAlign = titleTextAlign {
-            titleLabel!.textAlignment = titleTextAlign
+        if let titleTextAlign = titleTextAlign ,
+            let titleLabel = titleLabel{
+            titleLabel.textAlignment = titleTextAlign
         }
         
-        if let subtitleFont = subtitleFont {
+        if let subtitleFont = subtitleFont,
+            let subtitleLabel = subtitleLabel {
             self.subtitleFont = subtitleFont
-            subtitleLabel!.font = subtitleFont
+            subtitleLabel.font = subtitleFont
         }
         
-        if let subtitleColor = subtitleColor {
-            subtitleLabel!.textColor = subtitleColor
+        if let subtitleColor = subtitleColor,
+            let subtitleLabel = subtitleLabel  {
+            subtitleLabel.textColor = subtitleColor
         }
         
-        if let subtitleTextAlign = subtitleTextAlign {
-            subtitleLabel!.textAlignment = subtitleTextAlign
+        if let subtitleTextAlign = subtitleTextAlign,
+            let subtitleLabel = subtitleLabel  {
+            subtitleLabel.textAlignment = subtitleTextAlign
         }
         
         if titleFont != nil || subtitleFont != nil {

--- a/NotificationBanner/Classes/NotificationBanner.swift
+++ b/NotificationBanner/Classes/NotificationBanner.swift
@@ -193,28 +193,34 @@ public extension NotificationBanner {
             contentView.layer.cornerRadius = cornerRadius
         }
         
-        if let titleFont = titleFont {
-            titleLabel!.font = titleFont
+        if let titleFont = titleFont,
+            let titleLabel = titleLabel {
+            titleLabel.font = titleFont
         }
         
-        if let titleColor = titleColor {
-            titleLabel!.textColor = titleColor
+        if let titleColor = titleColor,
+            let titleLabel = titleLabel {
+            titleLabel.textColor = titleColor
         }
         
-        if let titleTextAlign = titleTextAlign {
-            titleLabel!.textAlignment = titleTextAlign
+        if let titleTextAlign = titleTextAlign,
+            let titleLabel = titleLabel {
+            titleLabel.textAlignment = titleTextAlign
         }
         
-        if let subtitleFont = subtitleFont {
-            subtitleLabel!.font = subtitleFont
+        if let subtitleFont = subtitleFont,
+            let subtitleLabel = subtitleLabel {
+            subtitleLabel.font = subtitleFont
         }
         
-        if let subtitleColor = subtitleColor {
-            subtitleLabel!.textColor = subtitleColor
+        if let subtitleColor = subtitleColor,
+            let subtitleLabel = subtitleLabel {
+            subtitleLabel.textColor = subtitleColor
         }
         
-        if let subtitleTextAlign = subtitleTextAlign {
-            subtitleLabel!.textAlignment = subtitleTextAlign
+        if let subtitleTextAlign = subtitleTextAlign,
+            let subtitleLabel = subtitleLabel {
+            subtitleLabel.textAlignment = subtitleTextAlign
         }
         
         if titleFont != nil || subtitleFont != nil {


### PR DESCRIPTION
when init the FloatingNotificationBanner without title
`let banner = FloatingNotificationBanner(title: nil, subtitle: text, titleFont: nil, titleColor: .lightGray, titleTextAlign: .left, subtitleFont: nil, subtitleColor: .black, subtitleTextAlign: .left, leftView: imageView, rightView: nil, style: .info, colors: bannerColors(), iconPosition: .top)`

the app crash, and that's because `titleLabel` get initialised only if `title` parameter was supplied


the same crash will happen when `applyStyling` for a `NotificationBanner` or a `GrowingNotificationBanner`
