### PR TITLE
Target MarqueeLabel Version 4.0.2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 # A scolling drop-in replacement for UILabel for long texts.
-github "cbpowell/MarqueeLabel" ~> 4.0.0
+github "cbpowell/MarqueeLabel" "4.0.2"
 
 # A Swift Autolayout DSL for iOS & OS X
 github "SnapKit/SnapKit" ~> 5.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "SnapKit/SnapKit" "5.0.1"
-github "cbpowell/MarqueeLabel" "4.0.0"
+github "cbpowell/MarqueeLabel" "4.0.2"


### PR DESCRIPTION
Version 4.0.3 of MarqueeLabel introduced a breaking change by increasing the deployment target from iOS 8 to iOS 12 so NotificationBanner is failing to build due to pulling 4.0.3 while still targeting iOS 10. Many apps and projects depend on NotificationBanner so I thought this would be a better solution that increasing the deployment target.