### PR TITLE
Fix crash in bannerPositionFrame when appWindow returns nil

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -154,7 +154,7 @@ open class BaseNotificationBanner: UIView {
             return UIApplication.shared.connectedScenes
                 .first { $0.activationState == .foregroundActive }
                 .map { $0 as? UIWindowScene }
-                .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? nil
+                .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? UIApplication.shared.keyWindow
         }
 
         return UIApplication.shared.delegate?.window ?? nil


### PR DESCRIPTION
In some case iOS13 returns `nil` when getting scene/window. Fix by adding `UIApplication.shared.keyWindow`.