### PR TITLE
Feature/314 add a11y support

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -374,7 +374,7 @@ open class BaseNotificationBanner: UIView {
 
             NotificationCenter.default.post(name: BaseNotificationBanner.BannerWillAppear, object: self, userInfo: notificationUserInfo)
             delegate?.notificationBannerWillAppear(self)
-			postAccessibilityNotification()
+            postAccessibilityNotification()
 
             let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.onTapGestureRecognizer))
             self.addGestureRecognizer(tapGestureRecognizer)
@@ -597,30 +597,30 @@ open class BaseNotificationBanner: UIView {
     }
 
 
-	/**
-		Posts a `UIAccessibility` notification when a notification appears.
-	*/
-	private func postAccessibilityNotification() {
-		var bannerAccessibilityLabel: String? = nil
-		switch self {
-		case let banner as NotificationBanner:
-			if let title = banner.titleLabel?.text, let subtitle = banner.subtitleLabel?.text {
-				bannerAccessibilityLabel = "\(title) \(subtitle)"
-			}
-		case let banner as FloatingNotificationBanner:
-			if let title = banner.titleLabel?.text, let subtitle = banner.subtitleLabel?.text {
-				bannerAccessibilityLabel = "\(title) \(subtitle)"
-			}
-		case let banner as GrowingNotificationBanner:
-			if let title = banner.titleLabel?.text, let subtitle = banner.subtitleLabel?.text {
-				bannerAccessibilityLabel = "\(title) \(subtitle)"
-			}
-		default:
-			break
-		}
-		accessibilityLabel = bannerAccessibilityLabel
-		isAccessibilityElement = true
-		UIAccessibility.post(notification: .screenChanged, argument: self)
-	}
+    /**
+     Posts a `UIAccessibility` notification when a notification appears.
+     */
+    private func postAccessibilityNotification() {
+        var bannerAccessibilityLabel: String? = nil
+        switch self {
+        case let banner as NotificationBanner:
+            if let title = banner.titleLabel?.text, let subtitle = banner.subtitleLabel?.text {
+                bannerAccessibilityLabel = "\(title) \(subtitle)"
+            }
+        case let banner as FloatingNotificationBanner:
+            if let title = banner.titleLabel?.text, let subtitle = banner.subtitleLabel?.text {
+                bannerAccessibilityLabel = "\(title) \(subtitle)"
+            }
+        case let banner as GrowingNotificationBanner:
+            if let title = banner.titleLabel?.text, let subtitle = banner.subtitleLabel?.text {
+                bannerAccessibilityLabel = "\(title) \(subtitle)"
+            }
+        default:
+            break
+        }
+        accessibilityLabel = bannerAccessibilityLabel
+        isAccessibilityElement = true
+        UIAccessibility.post(notification: .screenChanged, argument: self)
+    }
 }
 

--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -374,6 +374,7 @@ open class BaseNotificationBanner: UIView {
 
             NotificationCenter.default.post(name: BaseNotificationBanner.BannerWillAppear, object: self, userInfo: notificationUserInfo)
             delegate?.notificationBannerWillAppear(self)
+			postAccessibilityNotification()
 
             let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.onTapGestureRecognizer))
             self.addGestureRecognizer(tapGestureRecognizer)
@@ -594,5 +595,32 @@ open class BaseNotificationBanner: UIView {
     internal func updateMarqueeLabelsDurations() {
         (titleLabel as? MarqueeLabel)?.speed = .duration(CGFloat(duration <= 3 ? 0.5 : duration - 3))
     }
+
+
+	/**
+		Posts a `UIAccessibility` notification when a notification appears.
+	*/
+	private func postAccessibilityNotification() {
+		var bannerAccessibilityLabel: String? = nil
+		switch self {
+		case let banner as NotificationBanner:
+			if let title = banner.titleLabel?.text, let subtitle = banner.subtitleLabel?.text {
+				bannerAccessibilityLabel = "\(title) \(subtitle)"
+			}
+		case let banner as FloatingNotificationBanner:
+			if let title = banner.titleLabel?.text, let subtitle = banner.subtitleLabel?.text {
+				bannerAccessibilityLabel = "\(title) \(subtitle)"
+			}
+		case let banner as GrowingNotificationBanner:
+			if let title = banner.titleLabel?.text, let subtitle = banner.subtitleLabel?.text {
+				bannerAccessibilityLabel = "\(title) \(subtitle)"
+			}
+		default:
+			break
+		}
+		accessibilityLabel = bannerAccessibilityLabel
+		isAccessibilityElement = true
+		UIAccessibility.post(notification: .screenChanged, argument: self)
+	}
 }
 

--- a/NotificationBanner/Classes/GrowingNotificationBanner.swift
+++ b/NotificationBanner/Classes/GrowingNotificationBanner.swift
@@ -187,7 +187,7 @@ open class GrowingNotificationBanner: BaseNotificationBanner {
     }
 }
 
-public extensionngNotificationBanner {
+public extension GrowingNotificationBanner {
     
     func applyStyling(cornerRadius: CGFloat? = nil,
                       titleFont: UIFont? = nil,

--- a/NotificationBanner/Classes/GrowingNotificationBanner.swift
+++ b/NotificationBanner/Classes/GrowingNotificationBanner.swift
@@ -84,7 +84,7 @@ open class GrowingNotificationBanner: BaseNotificationBanner {
     private let innerSpacing: CGFloat = 2.5
     
     /// The bottom most label of the notification if a subtitle is provided
-    public private(set) var subtitleLabel: UILabel?
+	public internal(set) var subtitleLabel: UILabel?
     
     /// The view that is presented on the left side of the notification
     private var leftView: UIView?

--- a/NotificationBanner/Classes/GrowingNotificationBanner.swift
+++ b/NotificationBanner/Classes/GrowingNotificationBanner.swift
@@ -84,7 +84,7 @@ open class GrowingNotificationBanner: BaseNotificationBanner {
     private let innerSpacing: CGFloat = 2.5
     
     /// The bottom most label of the notification if a subtitle is provided
-	public internal(set) var subtitleLabel: UILabel?
+    public internal(set) var subtitleLabel: UILabel?
     
     /// The view that is presented on the left side of the notification
     private var leftView: UIView?
@@ -187,7 +187,7 @@ open class GrowingNotificationBanner: BaseNotificationBanner {
     }
 }
 
-public extension GrowingNotificationBanner {
+public extensionngNotificationBanner {
     
     func applyStyling(cornerRadius: CGFloat? = nil,
                       titleFont: UIFont? = nil,

--- a/NotificationBanner/Classes/NotificationBanner.swift
+++ b/NotificationBanner/Classes/NotificationBanner.swift
@@ -25,7 +25,7 @@ import MarqueeLabel
 open class NotificationBanner: BaseNotificationBanner {
     
     /// The bottom most label of the notification if a subtitle is provided
-    public private(set) var subtitleLabel: MarqueeLabel?
+	public internal(set) var subtitleLabel: MarqueeLabel?
     
     /// The view that is presented on the left side of the notification
     private var leftView: UIView?

--- a/NotificationBanner/Classes/NotificationBanner.swift
+++ b/NotificationBanner/Classes/NotificationBanner.swift
@@ -25,7 +25,7 @@ import MarqueeLabel
 open class NotificationBanner: BaseNotificationBanner {
     
     /// The bottom most label of the notification if a subtitle is provided
-	public internal(set) var subtitleLabel: MarqueeLabel?
+    public internal(set) var subtitleLabel: MarqueeLabel?
     
     /// The view that is presented on the left side of the notification
     private var leftView: UIView?


### PR DESCRIPTION
This Pull request solves: https://github.com/Daltron/NotificationBanner/issues/314

**What this does:**

Whenever a Banner is shown, a `UIAccessibility.Notification` will be posted now to make sure that users with enabled VoiceOver will be notified about the banner. It will read the banners `title` and its `subtitle`.

**How to test?**

Enable VoiceOver and trigger a banner.

Here is an example .mov video of the implementation.
[a11y_banner.mov.zip](https://github.com/Daltron/NotificationBanner/files/5380588/a11y_banner.mov.zip)

