### PR TITLE
Fix `appWindow` so it returns the correct window

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -151,10 +151,7 @@ open class BaseNotificationBanner: UIView {
     /// The main window of the application which banner views are placed on
     private let appWindow: UIWindow? = {
         if #available(iOS 13.0, *) {
-            return UIApplication.shared.connectedScenes
-                .first { $0.activationState == .foregroundActive }
-                .map { $0 as? UIWindowScene }
-                .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? nil
+            return UIApplication.shared.windows.filter {$0.isKeyWindow}.first
         }
 
         return UIApplication.shared.delegate?.window ?? nil


### PR DESCRIPTION
`NotificationBanner` has stopped working for us. I figured out that the reason was that `appWindow` is returning a wrong window. This PR fixes it and makes the code a little bit easier to read (`UIApplication.shared.windows.filter {$0.isKeyWindow}.first` seems clearer)