### PR TITLE
Sometimes app is visible but it's in inactive state. For example whil…

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -152,7 +152,7 @@ open class BaseNotificationBanner: UIView {
     private let appWindow: UIWindow? = {
         if #available(iOS 13.0, *) {
             return UIApplication.shared.connectedScenes
-                .first { $0.activationState == .foregroundActive }
+                .first { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive }
                 .map { $0 as? UIWindowScene }
                 .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? nil
         }


### PR DESCRIPTION
…e we are seeing to app window after dismissing the login with Apple pop up. So, if this state is not mentioned in the code, the app crash.