### PR TITLE
Fix backgroundColor set on style customView

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -184,7 +184,6 @@ open class BaseNotificationBanner: UIView {
         get {
             return contentView.backgroundColor
         } set {
-            guard style != .customView else { return }
             let color = newValue?.withAlphaComponent(transparency)
             contentView.backgroundColor = color
             spacerView.backgroundColor = color


### PR DESCRIPTION
This PR fixes an issue where background color set is not applied on `spacerView` and `contentView` of BaseNotificationBanner since the banner style is `.customView `
This issue makes the notch area have a different background color than the custom view background color

<img width="745" alt="Screen Shot 2021-02-10 at 5 29 25 PM" src="https://user-images.githubusercontent.com/33690767/107531467-8c35d680-6bc5-11eb-945d-1ce2f6e6112b.png">
