### PR TITLE
Fix compile time error in Xcode 13 beta

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -21,6 +21,7 @@ import SnapKit
 
 import MarqueeLabel
 
+@available(iOSApplicationExtension, unavailable)
 public protocol NotificationBannerDelegate: class {
     func notificationBannerWillAppear(_ banner: BaseNotificationBanner)
     func notificationBannerDidAppear(_ banner: BaseNotificationBanner)
@@ -29,6 +30,7 @@ public protocol NotificationBannerDelegate: class {
 }
 
 @objcMembers
+@available(iOSApplicationExtension, unavailable)
 open class BaseNotificationBanner: UIView {
 
     /// Notification that will be posted when a notification banner will appear
@@ -672,7 +674,6 @@ open class BaseNotificationBanner: UIView {
     /**
          Determines wether or not we should adjust the banner for notch featured iPhone
      */
-
     internal func shouldAdjustForNotchFeaturedIphone() -> Bool {
         return NotificationBannerUtilities.isNotchFeaturedIPhone()
             && UIApplication.shared.statusBarOrientation.isPortrait

--- a/NotificationBanner/Classes/FloatingNotificationBanner.swift
+++ b/NotificationBanner/Classes/FloatingNotificationBanner.swift
@@ -19,6 +19,7 @@
 import UIKit
 import SnapKit
 
+@available(iOSApplicationExtension, unavailable)
 open class FloatingNotificationBanner: GrowingNotificationBanner {
     
     public init(
@@ -139,6 +140,7 @@ open class FloatingNotificationBanner: GrowingNotificationBanner {
     
 }
 
+@available(iOSApplicationExtension, unavailable)
 private extension FloatingNotificationBanner {
     
     /**

--- a/NotificationBanner/Classes/GrowingNotificationBanner.swift
+++ b/NotificationBanner/Classes/GrowingNotificationBanner.swift
@@ -19,6 +19,7 @@
 import UIKit
 import SnapKit
 
+@available(iOSApplicationExtension, unavailable)
 open class GrowingNotificationBanner: BaseNotificationBanner {
     
     public enum IconPosition {
@@ -189,6 +190,7 @@ open class GrowingNotificationBanner: BaseNotificationBanner {
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 public extension GrowingNotificationBanner {
     
     func applyStyling(

--- a/NotificationBanner/Classes/NotificationBanner.swift
+++ b/NotificationBanner/Classes/NotificationBanner.swift
@@ -22,6 +22,7 @@ import SnapKit
 import MarqueeLabel
 
 @objcMembers
+@available(iOSApplicationExtension, unavailable)
 open class NotificationBanner: BaseNotificationBanner {
     
     /// The bottom most label of the notification if a subtitle is provided
@@ -183,6 +184,7 @@ open class NotificationBanner: BaseNotificationBanner {
     
 }
 
+@available(iOSApplicationExtension, unavailable)
 public extension NotificationBanner {
     
     func applyStyling(

--- a/NotificationBanner/Classes/NotificationBannerQueue.swift
+++ b/NotificationBanner/Classes/NotificationBannerQueue.swift
@@ -25,6 +25,7 @@ public enum QueuePosition: Int {
 }
 
 @objcMembers
+@available(iOSApplicationExtension, unavailable)
 open class NotificationBannerQueue: NSObject {
 
     /// The default instance of the NotificationBannerQueue

--- a/NotificationBanner/Classes/NotificationBannerUtilities.swift
+++ b/NotificationBanner/Classes/NotificationBannerUtilities.swift
@@ -20,6 +20,7 @@ import UIKit
 
 class NotificationBannerUtilities: NSObject {
 
+    @available(iOSApplicationExtension, unavailable)
     class func isNotchFeaturedIPhone() -> Bool {
         if #available(iOS 11, *) {
             if UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0 > CGFloat(0) {

--- a/NotificationBanner/Classes/StatusBarNotificationBanner.swift
+++ b/NotificationBanner/Classes/StatusBarNotificationBanner.swift
@@ -21,6 +21,7 @@ import UIKit
 import MarqueeLabel
 
 @objcMembers
+@available(iOSApplicationExtension, unavailable)
 open class StatusBarNotificationBanner: BaseNotificationBanner {
 
     public override var bannerHeight: CGFloat {
@@ -94,6 +95,7 @@ open class StatusBarNotificationBanner: BaseNotificationBanner {
 
 }
 
+@available(iOSApplicationExtension, unavailable)
 public extension StatusBarNotificationBanner {
     
     func applyStyling(


### PR DESCRIPTION
When compiling in Xcode 13 beta 3 this error occurs:
`'shared' is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead.`

It happens everywhere `UIApplication.shared` was called.

Solved by marking the classes/extensions/methods that either directly or indirectly call it as explicitly unavailable in app extensions.
There might be a cleaner way to do this, but seems like this solved the immediate problem.

See: https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes - issue 66928265 for the change in Xcode that introduced the surfacing of this error. Attached part of screenshot from that site below showing the relevant section:

![Screenshot 2021-08-05 at 17 27 43](https://user-images.githubusercontent.com/3153799/128377314-87c1c69d-7d18-4a6e-bdb6-4dbe52b00c42.png)

Tested on Xcode 13 beta 3 and beta 4, where it compiles successfully.

This should probably fix: https://github.com/Daltron/NotificationBanner/issues/358