### PR TITLE
[GEN] Fix crash when bannerPositionFrame == nil

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -377,6 +377,11 @@ open class BaseNotificationBanner: UIView {
                 queuePosition: queuePosition
             )
         } else {
+            guard bannerPositionFrame != nil else {
+                remove();
+                return
+            }
+
             self.frame = bannerPositionFrame.startFrame
 
             if let parentViewController = parentViewController {

--- a/NotificationBanner/Classes/NotificationBanner.swift
+++ b/NotificationBanner/Classes/NotificationBanner.swift
@@ -178,7 +178,7 @@ open class NotificationBanner: BaseNotificationBanner {
     
     internal override func updateMarqueeLabelsDurations() {
         super.updateMarqueeLabelsDurations()
-        subtitleLabel?.speed = .duration(CGFloat(duration <= 3 ? 0.5 : duration - 3))
+        subtitleLabel?.speed = .duration(CGFloat(duration <= 1 ? 1 : duration - 1))
     }
     
 }

--- a/NotificationBannerSwift.podspec
+++ b/NotificationBannerSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'NotificationBannerSwift'
-    s.version          = '3.0.6.1'
+    s.version          = '3.0.6.2'
     s.summary          = 'The easiest way to display in app notification banners in iOS.'
 
     s.description      = <<-DESC

--- a/NotificationBannerSwift.podspec
+++ b/NotificationBannerSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'NotificationBannerSwift'
-    s.version          = '3.0.6'
+    s.version          = '3.0.6.1'
     s.summary          = 'The easiest way to display in app notification banners in iOS.'
 
     s.description      = <<-DESC


### PR DESCRIPTION
We happened to root caused this issue when the notification was sent after the app became inactive.

We did some code to send the notification, and this part of code was triggered when app become inactive.
This causes crash every time, the root cause is bannerPositionFrame is nil.