### PR TITLE
Prevent rapid clicking of notification banner from showing too many banners at once, with incorrect Y offsets

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -57,8 +57,12 @@ open class BaseNotificationBanner: UIView {
         get {
             if let customBannerHeight = customBannerHeight {
                 return customBannerHeight
+            } else if shouldAdjustForDynamicIsland() {
+                return 104.0
+            } else if shouldAdjustForNotchFeaturedIphone() {
+                return 88.0
             } else {
-                return shouldAdjustForNotchFeaturedIphone() ? 88.0 : 64.0 + heightAdjustment
+                return 64.0 + heightAdjustment
             }
         } set {
             customBannerHeight = newValue
@@ -273,9 +277,13 @@ open class BaseNotificationBanner: UIView {
     }
 
     internal func spacerViewHeight() -> CGFloat {
-        return NotificationBannerUtilities.isNotchFeaturedIPhone()
-            && UIApplication.shared.statusBarOrientation.isPortrait
-            && (parentViewController?.navigationController?.isNavigationBarHidden ?? true) ? 40.0 : 10.0
+        if shouldAdjustForDynamicIsland() {
+            return 44.0
+        } else if shouldAdjustForNotchFeaturedIphone() {
+            return 40.0
+        } else {
+            return 10.0
+        }
     }
 
     private func finishBannerYOffset() -> CGFloat {
@@ -501,6 +509,10 @@ open class BaseNotificationBanner: UIView {
         The height adjustment needed in order for the banner to look properly displayed.
      */
     internal var heightAdjustment: CGFloat {
+        if NotificationBannerUtilities.hasDynamicIsland() {
+            return 16.0
+        }
+        
         // iOS 13 does not allow covering the status bar on non-notch iPhones
         // The banner needs to be moved further down under the status bar in this case
         guard #available(iOS 13.0, *), !NotificationBannerUtilities.isNotchFeaturedIPhone() else {
@@ -688,6 +700,12 @@ open class BaseNotificationBanner: UIView {
          Determines wether or not we should adjust the banner for notch featured iPhone
      */
 
+    internal func shouldAdjustForDynamicIsland() -> Bool {
+        return NotificationBannerUtilities.hasDynamicIsland()
+            && UIApplication.shared.statusBarOrientation.isPortrait
+            && (self.parentViewController?.navigationController?.isNavigationBarHidden ?? true)
+    }
+    
     internal func shouldAdjustForNotchFeaturedIphone() -> Bool {
         return NotificationBannerUtilities.isNotchFeaturedIPhone()
             && UIApplication.shared.statusBarOrientation.isPortrait

--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -573,11 +573,15 @@ open class BaseNotificationBanner: UIView {
         isDisplaying = false
         remove()
 
+        // Prevent any user action from showing an additional animation
+        self.bannerQueue.activeAnimation = true
+
         UIView.animate(
             withDuration: forced ? animationDuration / 2 : animationDuration,
             animations: {
                 self.frame = self.bannerPositionFrame.startFrame
         }) { (completed) in
+            self.bannerQueue.activeAnimation = false
 
             self.removeFromSuperview()
 

--- a/NotificationBanner/Classes/NotificationBannerQueue.swift
+++ b/NotificationBanner/Classes/NotificationBannerQueue.swift
@@ -36,6 +36,10 @@ open class NotificationBannerQueue: NSObject {
     /// The notification banners currently placed on the queue
     private(set) var maxBannersOnScreenSimultaneously: Int = 1
 
+    /// This is a mutex to prevent too many notification banners from appearing on screen at once
+    /// while our BaseNotificationBanner is animating itself off screen
+    public var activeAnimation = false
+
     /// The current number of notification banners on the queue
     public var numberOfBanners: Int {
         return banners.count
@@ -61,7 +65,7 @@ open class NotificationBannerQueue: NSObject {
             banners.append(banner)
 
             let bannersCount =  banners.filter { $0.isDisplaying }.count
-            if bannersCount < maxBannersOnScreenSimultaneously {
+            if bannersCount < maxBannersOnScreenSimultaneously && self.activeAnimation == false {
                 banner.show(placeOnQueue: false, bannerPosition: banner.bannerPosition)
             }
 

--- a/NotificationBanner/Classes/NotificationBannerUtilities.swift
+++ b/NotificationBanner/Classes/NotificationBannerUtilities.swift
@@ -22,7 +22,19 @@ class NotificationBannerUtilities: NSObject {
 
     class func isNotchFeaturedIPhone() -> Bool {
         if #available(iOS 11, *) {
-            if UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0 > CGFloat(0) {
+            if UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0.0 > 0.0 {
+                return true
+            } else {
+                return false
+            }
+        } else {
+            return false
+        }
+    }
+    
+    class func hasDynamicIsland() -> Bool {
+        if #available(iOS 11, *) {
+            if UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0.0 > 50.0 {
                 return true
             } else {
                 return false

--- a/NotificationBanner/Classes/StatusBarNotificationBanner.swift
+++ b/NotificationBanner/Classes/StatusBarNotificationBanner.swift
@@ -27,6 +27,8 @@ open class StatusBarNotificationBanner: BaseNotificationBanner {
         get {
             if let customBannerHeight = customBannerHeight {
                 return customBannerHeight
+            } else if shouldAdjustForDynamicIsland() {
+                return 70.0
             } else if shouldAdjustForNotchFeaturedIphone() {
                 return 50.0
             } else {


### PR DESCRIPTION
See this movie for what can happen if you rapidly click to create new notification banners while there is an active UIAnimation running:

![NotificationBannerBug (1)](https://user-images.githubusercontent.com/58332/178534354-41dbd667-7c32-46e0-a5d2-0bcfb3734177.gif)

