### PR TITLE
Make every type work with dynamic island

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -57,8 +57,12 @@ open class BaseNotificationBanner: UIView {
         get {
             if let customBannerHeight = customBannerHeight {
                 return customBannerHeight
+            } else if shouldAdjustForDynamicIsland() {
+                return 104.0
+            } else if shouldAdjustForNotchFeaturedIphone() {
+                return 88.0
             } else {
-                return shouldAdjustForNotchFeaturedIphone() ? 88.0 : 64.0 + heightAdjustment
+                return 64.0 + heightAdjustment
             }
         } set {
             customBannerHeight = newValue
@@ -273,9 +277,13 @@ open class BaseNotificationBanner: UIView {
     }
 
     internal func spacerViewHeight() -> CGFloat {
-        return NotificationBannerUtilities.isNotchFeaturedIPhone()
-            && UIApplication.shared.statusBarOrientation.isPortrait
-            && (parentViewController?.navigationController?.isNavigationBarHidden ?? true) ? 40.0 : 10.0
+        if shouldAdjustForDynamicIsland() {
+            return 44.0
+        } else if shouldAdjustForNotchFeaturedIphone() {
+            return 40.0
+        } else {
+            return 10.0
+        }
     }
 
     private func finishBannerYOffset() -> CGFloat {
@@ -501,6 +509,10 @@ open class BaseNotificationBanner: UIView {
         The height adjustment needed in order for the banner to look properly displayed.
      */
     internal var heightAdjustment: CGFloat {
+        if NotificationBannerUtilities.hasDynamicIsland() {
+            return 16.0
+        }
+        
         // iOS 13 does not allow covering the status bar on non-notch iPhones
         // The banner needs to be moved further down under the status bar in this case
         guard #available(iOS 13.0, *), !NotificationBannerUtilities.isNotchFeaturedIPhone() else {
@@ -684,6 +696,12 @@ open class BaseNotificationBanner: UIView {
          Determines wether or not we should adjust the banner for notch featured iPhone
      */
 
+    internal func shouldAdjustForDynamicIsland() -> Bool {
+        return NotificationBannerUtilities.hasDynamicIsland()
+            && UIApplication.shared.statusBarOrientation.isPortrait
+            && (self.parentViewController?.navigationController?.isNavigationBarHidden ?? true)
+    }
+    
     internal func shouldAdjustForNotchFeaturedIphone() -> Bool {
         return NotificationBannerUtilities.isNotchFeaturedIPhone()
             && UIApplication.shared.statusBarOrientation.isPortrait

--- a/NotificationBanner/Classes/NotificationBannerUtilities.swift
+++ b/NotificationBanner/Classes/NotificationBannerUtilities.swift
@@ -22,7 +22,19 @@ class NotificationBannerUtilities: NSObject {
 
     class func isNotchFeaturedIPhone() -> Bool {
         if #available(iOS 11, *) {
-            if UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0 > CGFloat(0) {
+            if UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0.0 > 0.0 {
+                return true
+            } else {
+                return false
+            }
+        } else {
+            return false
+        }
+    }
+    
+    class func hasDynamicIsland() -> Bool {
+        if #available(iOS 11, *) {
+            if UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0.0 > 50.0 {
                 return true
             } else {
                 return false

--- a/NotificationBanner/Classes/StatusBarNotificationBanner.swift
+++ b/NotificationBanner/Classes/StatusBarNotificationBanner.swift
@@ -27,6 +27,8 @@ open class StatusBarNotificationBanner: BaseNotificationBanner {
         get {
             if let customBannerHeight = customBannerHeight {
                 return customBannerHeight
+            } else if shouldAdjustForDynamicIsland() {
+                return 70.0
             } else if shouldAdjustForNotchFeaturedIphone() {
                 return 50.0
             } else {


### PR DESCRIPTION
This PR solves the issue with the banners ending up behind the dynamic island. I have tried all on iPhone 14 Pro and Max and  also tried it on iPhone 14 to make sure nothing broke.

Things to note:
* Not sure the hasDynamicIsland logic is correct. It worked on the different simulators I tried.
* Not sure I have manipulated the height and the margins in the right place. Maybe there is a better way to do it.
* Not sure the numbers are perfect. Could be some more padding for certain types but not very knowledgable about the project to make it work perfect for all.

Fixes #394