### PR TITLE
Multiple scene support for iPad

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -157,7 +157,9 @@ open class BaseNotificationBanner: UIView {
             return UIApplication.shared.connectedScenes
                 .first { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive }
                 .map { $0 as? UIWindowScene }
-                .flatMap { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? UIApplication.shared.keyWindow
+                .flatMap { $0?.windows.first } ?? UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first { $0.isKeyWindow }
         }
 
         return UIApplication.shared.delegate?.window ?? nil


### PR DESCRIPTION
Fixed warning to conform to new standards. Allows for multiple scans, especially when used on an iPad. No effect on iPhone usage as there is only one scene