### PR TITLE
Fix bannerPosition being nil crash

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -168,7 +168,7 @@ open class BaseNotificationBanner: UIView {
     }()
 
     /// The position the notification banner should slide in from
-    private(set) var bannerPosition: BannerPosition!
+    private(set) var bannerPosition: BannerPosition = .top
 
     /// The notification banner sides edges insets from superview. If presented - spacerView color will be transparent
     internal var bannerEdgeInsets: UIEdgeInsets? = nil {

--- a/NotificationBanner/Classes/GrowingNotificationBanner.swift
+++ b/NotificationBanner/Classes/GrowingNotificationBanner.swift
@@ -60,9 +60,20 @@ open class GrowingNotificationBanner: BaseNotificationBanner {
                 let subtitleHeight = ceil(subtitleLabel?.sizeThatFits(
                     CGSize(width: boundingWidth,
                            height: .greatestFiniteMagnitude)).height ?? 0.0)
-                
-                let topOffset: CGFloat = shouldAdjustForNotchFeaturedIphone() ? 44.0 : verticalSpacing
-                let minHeight: CGFloat = shouldAdjustForNotchFeaturedIphone() ? 88.0 : 64.0
+             
+                let topOffset: CGFloat
+                let minHeight: CGFloat
+
+                if shouldAdjustForNotchFeaturedIphone() {
+                    topOffset = 44.0
+                    minHeight = 88.0
+                } else if shouldAdjustForDynamicIsland() {
+                    topOffset = 44.0
+                    minHeight = 104.0
+                } else {
+                    topOffset = verticalSpacing
+                    minHeight = 64.0
+                }
                 
                 var actualBannerHeight = topOffset + titleHeight + subtitleHeight + verticalSpacing
                 


### PR DESCRIPTION
`bannerPosition` is no longer optional. Defaulting the `bannerPosition` value to` .top` avoids cases where bannerPosition is accessed before it is set, and aligns with the documentation that says "By default, each banner will present from the top.".

Closes #333 