### PR TITLE
Fix bannerPosition being nil crash

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -168,7 +168,7 @@ open class BaseNotificationBanner: UIView {
     }()
 
     /// The position the notification banner should slide in from
-    private(set) var bannerPosition: BannerPosition!
+    private(set) var bannerPosition: BannerPosition = .top
 
     /// The notification banner sides edges insets from superview. If presented - spacerView color will be transparent
     internal var bannerEdgeInsets: UIEdgeInsets? = nil {


### PR DESCRIPTION
`bannerPosition` is no longer optional. Defaulting the `bannerPosition` value to `.top` avoids cases where `bannerPosition` is accessed before it is set, and aligns with the documentation that says "By default, each banner will present from the top.".

Closes #333