### PR TITLE
Fix rightView layout

### DIFF
--- a/NotificationBanner/Classes/NotificationBanner.swift
+++ b/NotificationBanner/Classes/NotificationBanner.swift
@@ -68,7 +68,7 @@ open class NotificationBanner: BaseNotificationBanner {
             let size = (rightView.frame.height > 0) ? min(44, rightView.frame.height) : 44
             rightView.snp.makeConstraints({ (make) in
                 make.centerY.equalToSuperview().offset(heightAdjustment / 4)
-                make.left.equalToSuperview().offset(10)
+                make.right.equalToSuperview().offset(-10)
                 make.size.equalTo(size)
             })
         }


### PR DESCRIPTION
The rightView is currently pinned to the left of the contentView which broke the layout.