### PR TITLE
Update minimum IOS version to 12.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "NotificationBannerSwift",
     platforms: [
-        .iOS(.v10)
+        .iOS(.v12)
     ],
     products: [
         .library(name: "NotificationBannerSwift", targets: ["NotificationBannerSwift"])

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ NotificationBanner is an extremely customizable and lightweight library that mak
 
 ## Requirements
 
- - iOS 10.0+
+ - iOS 12.0+
  - Xcode 10.0+
 
 ## Installation


### PR DESCRIPTION
The SnapKit dependency requires IOS 12.0, so having an IOS 10.0 minimum requirement doesn't allow the package to build.