### PR TITLE
Making sure FloatingNotificationBanner is always in front of all views

### DIFF
--- a/NotificationBanner/Classes/FloatingNotificationBanner.swift
+++ b/NotificationBanner/Classes/FloatingNotificationBanner.swift
@@ -34,7 +34,8 @@ open class FloatingNotificationBanner: GrowingNotificationBanner {
         rightView: UIView? = nil,
         style: BannerStyle = .info,
         colors: BannerColorsProtocol? = nil,
-        iconPosition: IconPosition = .center
+        iconPosition: IconPosition = .center,
+        alwaysInFront: Bool = true
     ) {
 
         super.init(
@@ -72,9 +73,13 @@ open class FloatingNotificationBanner: GrowingNotificationBanner {
         if let subtitleTextAlign = subtitleTextAlign {
             subtitleLabel!.textAlignment = subtitleTextAlign
         }
+ 
+        if alwaysInFront {
+            setAlwaysInFront()
+        }
     }
     
-    public init(customView: UIView) {
+    public init(customView: UIView, alwaysInFront: Bool = false) {
         super.init(style: .customView)
         self.customView = customView
         
@@ -84,6 +89,10 @@ open class FloatingNotificationBanner: GrowingNotificationBanner {
         }
         
         spacerView.backgroundColor = customView.backgroundColor
+
+        if alwaysInFront {
+            setAlwaysInFront()
+        }
     }
     
     /**
@@ -174,4 +183,7 @@ private extension FloatingNotificationBanner {
         contentView.layer.shouldRasterize = true
     }
     
+    private func setAlwaysInFront() {
+        self.layer.zPosition = CGFloat(Float.greatestFiniteMagnitude)
+    }
 }

--- a/NotificationBannerSwift.podspec
+++ b/NotificationBannerSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'NotificationBannerSwift'
-    s.version          = '3.2.1'
+    s.version          = '3.3.0'
     s.summary          = 'The easiest way to display in app notification banners in iOS.'
 
     s.description      = <<-DESC


### PR DESCRIPTION
This PR ensures that the FloatingNotificationBanner is always in front of all views. We found a bug where the notification was getting hidden behind a controller which was presented immediately after showing a `FloatingBannerView`. 