### PR TITLE
Fixed wrong banner dimensions due to the wrong orientation detection

### DIFF
--- a/NotificationBanner/Classes/UIWindow+orientation.swift
+++ b/NotificationBanner/Classes/UIWindow+orientation.swift
@@ -10,27 +10,66 @@ import UIKit
 extension UIWindow {
 
     public var width: CGFloat {
-        let orientation = UIDevice.current.orientation
-        switch orientation {
-        case .landscapeLeft, .landscapeRight:
-            return max(frame.width, frame.height)
-        case .portrait, .portraitUpsideDown:
-            return min(frame.width, frame.height)
-        default:
-            return frame.width
+        if #available(iOS 13.0, *) {
+            if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                let orientation = UIApplication.shared.supportedInterfaceOrientations(for: scene.windows.first)
+                switch orientation {
+                case .landscapeLeft, .landscapeRight:
+                    return max(frame.width, frame.height)
+                case .portrait, .portraitUpsideDown:
+                    return min(frame.width, frame.height)
+                default:
+                    return frame.width
+                }
+            } else {
+                return getDefaultWidth()
+            }
+        } else {
+            return getDefaultWidth()
+        }
+
+        func getDefaultWidth() -> CGFloat {
+            let orientation = UIDevice.current.orientation
+            switch orientation {
+            case .landscapeLeft, .landscapeRight:
+                return max(frame.width, frame.height)
+            case .portrait, .portraitUpsideDown:
+                return min(frame.width, frame.height)
+            default:
+                return frame.width
+            }
         }
     }
 
     public var height: CGFloat {
-        let orientation = UIDevice.current.orientation
-        switch orientation {
-        case .landscapeLeft, .landscapeRight:
-            return min(frame.width, frame.height)
-        case .portrait, .portraitUpsideDown:
-            return max(frame.width, frame.height)
-        default:
-            return frame.height
+        if #available(iOS 13.0, *) {
+            if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                let orientation = UIApplication.shared.supportedInterfaceOrientations(for: scene.windows.first)
+                switch orientation {
+                case .landscapeLeft, .landscapeRight:
+                    return min(frame.width, frame.height)
+                case .portrait, .portraitUpsideDown:
+                    return max(frame.width, frame.height)
+                default:
+                    return frame.height
+                }
+            } else {
+                return getDefaultHeight()
+            }
+        } else {
+            return getDefaultHeight()
+        }
+
+        func getDefaultHeight() -> CGFloat {
+            let orientation = UIDevice.current.orientation
+            switch orientation {
+            case .landscapeLeft, .landscapeRight:
+                return min(frame.width, frame.height)
+            case .portrait, .portraitUpsideDown:
+                return max(frame.width, frame.height)
+            default:
+                return frame.height
+            }
         }
     }
-
 }


### PR DESCRIPTION
In a portrait application (in which the landscape is closed), if the device is not placed in a portrait state, the app will still be shown as portrait but the banner thinks the device is in landscape mode and shows the banner with the wrong dimensions.